### PR TITLE
Added life cycle assessment workshop in Stuttgart

### DIFF
--- a/assets/confs.yaml
+++ b/assets/confs.yaml
@@ -160,6 +160,13 @@ events:
     continent: Online
     link: https://indico.esa.int/event/645/overview
 
+  - title: 4th Workshop on Life Cycle Assessment of Space Transportation Systems
+    startDate: 2026-09-01
+    endDate: 2026-09-03
+    location: Stuttgart, Germany
+    continent: Europe
+    link: https://docs.google.com/forms/d/e/1FAIpQLSf-rPNRURUesFdP9MRmNWWkaGoN5Ot7ittVo6bpiBI6NtXifA/viewform?pli=1
+
 pastEvents:
   - title: International Conjunction Assessment Workshop 2025
     startDate: 2025-06-18

--- a/hugo.toml
+++ b/hugo.toml
@@ -9,6 +9,6 @@ theme = "hugo-bearblog"
 
 [params]
 favicon = "images/favicon.png"
-lastUpdate = "2026-03-12T00:00:00"
+lastUpdate = "2026-03-17T00:00:00"
 githubURL = "https://github.com/zurdala/space-debris-confs"
 githubURLIssue = "https://github.com/zurdala/space-debris-confs/issues/new?template=11-new-conference.md"


### PR DESCRIPTION
- From what I see this is not really focussed on space debris but still adjacent 
- No conference website yet, I put the link to the registration form instead
- there may be an issue with how the last updated field is shown on the website I think the formatting might always put Feb instead of the correct month but I'm not sure