### PR TITLE
Update event details and move ICSSA to pastEvents

### DIFF
--- a/assets/confs.yaml
+++ b/assets/confs.yaml
@@ -62,13 +62,6 @@ events:
     continent: Asia
     link: https://www.spaceops.org/events/workshops/sops2026-workshop/
 
-  - title: 5th IAA Conference on Space Situational Awareness (ICSSA)
-    startDate: 2026-04-07
-    endDate: 2026-04-09
-    location: Tres Cantos, Madrid, Spain
-    continent: Europe
-    link: https://web.cvent.com/event/dffa94f9-d8cf-4201-88ae-f8d0a3049700/summary?environment=P2
-
   - title: SSA Operators Workshop 2026
     startDate: 2026-06-02
     endDate: 2026-06-06
@@ -154,6 +147,13 @@ events:
     link: https://docs.google.com/forms/d/e/1FAIpQLSf-rPNRURUesFdP9MRmNWWkaGoN5Ot7ittVo6bpiBI6NtXifA/viewform?pli=1
 
 pastEvents:
+  - title: 5th IAA Conference on Space Situational Awareness (ICSSA)
+    startDate: 2026-04-07
+    endDate: 2026-04-09
+    location: Tres Cantos, Madrid, Spain
+    continent: Europe
+    link: https://web.cvent.com/event/dffa94f9-d8cf-4201-88ae-f8d0a3049700/summary?environment=P2
+    
   - title: DRAMA Clinics & Workshop on probabilistic re-entry modelling
     startDate: 2026-03-23
     endDate: 2026-03-24

--- a/hugo.toml
+++ b/hugo.toml
@@ -9,6 +9,6 @@ theme = "hugo-bearblog"
 
 [params]
 favicon = "images/favicon.png"
-lastUpdate = "2026-03-26T00:00:00"
+lastUpdate = "2026-04-13T00:00:00"
 githubURL = "https://github.com/zurdala/space-debris-confs"
 githubURLIssue = "https://github.com/zurdala/space-debris-confs/issues/new?template=11-new-conference.md"


### PR DESCRIPTION
Moved the 5th IAA Conference on Space Situational Awareness (ICSSA) to pastEvents section and updated its details.